### PR TITLE
chore(deps): add fiddle to gemspec due to migration warnings

### DIFF
--- a/packaging/Gemfile
+++ b/packaging/Gemfile
@@ -11,3 +11,4 @@ gem "webrick", "1.9.1"
 # due to lack of windows support
 gem "json", "2.7.1"
 gem "bigdecimal", "3.1.5"
+gem "fiddle", "1.1.2"

--- a/packaging/Gemfile.lock
+++ b/packaging/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     dig_rb (1.0.1)
     expgen (0.1.1)
       parslet
-    faraday (2.13.1)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -17,6 +17,7 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.3.2)
       faraday (~> 2.0)
+    fiddle (1.1.2)
     find_a_port (1.0.1)
     httparty (0.23.1)
       csv
@@ -27,12 +28,12 @@ GEM
       multi_json
     logger (1.7.0)
     mini_mime (1.1.5)
-    multi_json (1.15.0)
+    multi_json (1.17.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     net-http (0.6.0)
       uri
-    ostruct (0.6.2)
+    ostruct (0.6.3)
     pact (1.66.1)
       jsonpath (~> 1.0)
       pact-mock_service (~> 3.0, >= 3.3.1)
@@ -144,6 +145,7 @@ PLATFORMS
 
 DEPENDENCIES
   bigdecimal (= 3.1.5)
+  fiddle (= 1.1.2)
   json (= 2.7.1)
   pact (= 1.66.1)
   pact-message (= 0.11.1)


### PR DESCRIPTION
will be removed as standard gem from ruby 3.5.x